### PR TITLE
Change to merge data from config file into config object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require('path'),
-	fs = require('fs');
+	fs = require('fs'),
+	extend = require('object-extend');
 
 var config = module.exports = function(opts) {
 	opts = opts || {};
@@ -17,9 +18,7 @@ var config = module.exports = function(opts) {
 	// else handled by native require() (directory(''), js, json and others) 
 	var data = ext in opts ? opts[ext](fs.readFileSync(file, 'utf8')) : require(file);
 
-	for (var key in data) {
-		config[key] = data[key];
-	}
+	extend(config, data);
 
 	return config;
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "node": "*",
     "npm": "*"
   },
-  "dependencies": {},
+  "dependencies": {
+    "object-extend": "^0.5.0"
+  },
   "devDependencies": {
     "mocha": "*",
     "chai": "*"


### PR DESCRIPTION
I load both a `common.json` config file and an environment-specific config file `development.json`. The config contains values that are hashes, and when I load the `development.json` config file, these hashes are overwritten rather than merged. 

This PR merges the data from the config file into the config object so that hashes aren't overwritten.

I've used `object-extend` module, but I can copy the merge function in if you don't want the dependancy.

I initially tried to do this outside the module, but it's a bit clumsy because I had to `deepClone()` the common config in order to merge it with the environment config.
