### PR TITLE
Avoid loading config from files that begin with the environment, but not followed by a "."

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,15 +22,20 @@ var config = module.exports = function(opts) {
 };
 
 function extension(dir, env) {
-	var file = fs.readdirSync(dir).filter(function(filename) {
-		return filename.indexOf(env) === 0;
+	var prefix = env + '.';
+	var file = fs.readdirSync(dir).sort().filter(function(filename) {
+		if (filename.indexOf(prefix) === 0) {
+			return true;
+		}
+		else if (fs.statSync(path.join(dir, filename)).isDirectory()) {
+			return filename.indexOf(env) === 0;
+		}
 	})[0];
 
 	if (!file) {
 		throw new Error('No file found for environment '+env);
 	}
-
-	return file.slice(env.length+1);
+	return file.slice(prefix.length);
 }
 
 function copy(dest, src) {

--- a/test/config/should-be.loaded.json
+++ b/test/config/should-be.loaded.json
@@ -1,0 +1,4 @@
+{
+	"env": "should-be",
+	"ext": "loaded.json"
+}

--- a/test/config/should-not-be-loaded.json
+++ b/test/config/should-not-be-loaded.json
@@ -1,0 +1,4 @@
+{
+	"env": "should-not-be",
+	"ext": "json"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -103,6 +103,24 @@ describe('config-node', function() {
 			expect(config.ext).to.equal('json');
 		});
 
+		it('should not load files that begin with env followed by a character other than "."', function() {
+			expect(function () {
+				config({env: 'should-not-be'});
+			}).to.throw('No file found for environment should-not-be');
+		});
+
+		it('should load files that begin with env followed by a "."', function() {
+			function parser(data) {
+				var obj = JSON.parse(data);
+				obj.called = true;
+				return obj;
+			}
+			config({env:'should-be', 'loaded.json': parser});
+			expect(config.env).to.equal('should-be');
+			expect(config.ext).to.equal('loaded.json');
+			expect(config.called).to.be.true;
+		});
+
 		it('should work as usual when the ext has dots', function() {
 			function parser(data) {
 				var obj = JSON.parse(data);


### PR DESCRIPTION
I created a file called `development-example.json` in my `config/` directory, only to find that `config-node` happily decides to load this file. This PR preserves the previous behaviour, but would only load this file if it was called `development.example.json`.
